### PR TITLE
Check number of valid lines and instrument mode

### DIFF
--- a/emit_main/database/database_manager.py
+++ b/emit_main/database/database_manager.py
@@ -43,10 +43,12 @@ class DatabaseManager:
         }
         return list(acquisitions_coll.find(query).sort("acquisition_id", 1))
 
-    def find_acquisitions_touching_date_range(self, submode, field, start, stop, min_valid_lines=0, sort=1):
+    def find_acquisitions_touching_date_range(self, submode, field, start, stop, instrument_mode="cold_img",
+                                              min_valid_lines=0, sort=1):
         acquisitions_coll = self.db.acquisitions
         query = {
             "submode": submode,
+            "instrument_mode": instrument_mode,
             "num_valid_lines": {"$gte": min_valid_lines},
             field: {"$gte": start, "$lte": stop},
             "build_num": self.config["build_num"]
@@ -73,6 +75,7 @@ class DatabaseManager:
                 "stop_time",
                 acq["start_time"] - datetime.timedelta(minutes=400),
                 acq["start_time"],
+                instrument_mode=acq["instrument_mode"],
                 min_valid_lines=256,
                 sort=-1)
             if recent_darks is not None and len(recent_darks) > 0:

--- a/emit_main/workflow/l1a_tasks.py
+++ b/emit_main/workflow/l1a_tasks.py
@@ -416,6 +416,7 @@ class L1AReassembleRaw(SlurmJobTask):
             start_index = None
             stop_index = None
             num_valid_lines = None
+            instrument_mode = None
             with open(tmp_report_path, "r") as f:
                 for line in f.readlines():
                     if "Start time" in line:
@@ -430,6 +431,8 @@ class L1AReassembleRaw(SlurmJobTask):
                         stop_index = int(line.rstrip("\n").split(": ")[1])
                     if "Number of lines with valid data" in line:
                         num_valid_lines = int(line.rstrip("\n").split(": ")[1])
+                    if "Instrument mode:" in line:
+                        instrument_mode = line.rstrip("\n").split(": ")[1]
 
             # TODO: Check valid date?
             if start_time is None or stop_time is None:
@@ -457,6 +460,7 @@ class L1AReassembleRaw(SlurmJobTask):
                 "scene": scene,
                 "submode": submode.lower(),
                 "daynight": daynight,
+                "instrument_mode": instrument_mode,
                 "num_valid_lines": num_valid_lines,
                 "associated_dcid": self.dcid
             }

--- a/emit_main/workflow/l1a_tasks.py
+++ b/emit_main/workflow/l1a_tasks.py
@@ -415,7 +415,7 @@ class L1AReassembleRaw(SlurmJobTask):
             stop_time = None
             start_index = None
             stop_index = None
-            is_empty = None
+            has_min_proc_lines = None
             with open(tmp_report_path, "r") as f:
                 for line in f.readlines():
                     if "Start time" in line:
@@ -428,8 +428,8 @@ class L1AReassembleRaw(SlurmJobTask):
                         start_index = int(line.rstrip("\n").split(": ")[1])
                     if "Last frame number in acquisition" in line:
                         stop_index = int(line.rstrip("\n").split(": ")[1])
-                    if "Acquisition is empty" in line:
-                        is_empty = bool(line.rstrip("\n").split(": ")[1])
+                    if "Acquisition has min processable lines" in line:
+                        has_min_proc_lines = bool(line.rstrip("\n").split(": ")[1])
 
             # TODO: Check valid date?
             if start_time is None or stop_time is None:
@@ -457,7 +457,7 @@ class L1AReassembleRaw(SlurmJobTask):
                 "scene": scene,
                 "submode": submode.lower(),
                 "daynight": daynight,
-                "is_empty": is_empty,
+                "has_min_proc_lines": has_min_proc_lines,
                 "associated_dcid": self.dcid
             }
 

--- a/emit_main/workflow/l1a_tasks.py
+++ b/emit_main/workflow/l1a_tasks.py
@@ -415,7 +415,7 @@ class L1AReassembleRaw(SlurmJobTask):
             stop_time = None
             start_index = None
             stop_index = None
-            has_min_proc_lines = None
+            num_valid_lines = None
             with open(tmp_report_path, "r") as f:
                 for line in f.readlines():
                     if "Start time" in line:
@@ -428,8 +428,8 @@ class L1AReassembleRaw(SlurmJobTask):
                         start_index = int(line.rstrip("\n").split(": ")[1])
                     if "Last frame number in acquisition" in line:
                         stop_index = int(line.rstrip("\n").split(": ")[1])
-                    if "Acquisition has min processable lines" in line:
-                        has_min_proc_lines = bool(line.rstrip("\n").split(": ")[1])
+                    if "Number of lines with valid data" in line:
+                        num_valid_lines = int(line.rstrip("\n").split(": ")[1])
 
             # TODO: Check valid date?
             if start_time is None or stop_time is None:
@@ -457,7 +457,7 @@ class L1AReassembleRaw(SlurmJobTask):
                 "scene": scene,
                 "submode": submode.lower(),
                 "daynight": daynight,
-                "has_min_proc_lines": has_min_proc_lines,
+                "num_valid_lines": num_valid_lines,
                 "associated_dcid": self.dcid
             }
 

--- a/emit_main/workflow/l1b_tasks.py
+++ b/emit_main/workflow/l1b_tasks.py
@@ -88,7 +88,7 @@ class L1BCalibrate(SlurmJobTask):
             # Find dark image - Get most recent dark image, but throw error if not within last 200 minutes
             recent_darks = dm.find_acquisitions_touching_date_range(
                 "dark",
-                False,
+                True,
                 "stop_time",
                 acq.start_time - datetime.timedelta(minutes=200),
                 acq.start_time,
@@ -221,8 +221,8 @@ class L1BGeolocate(SlurmJobTask):
             raise RuntimeError(f"Unable to run {self.task_family} on {self.orbit_id} due to missing radiance files in "
                                f"orbit.")
 
-        # Get acquisitions in orbit (only non-empty science, not dark) - radiance and line timestamps
-        acquisitions_in_orbit = dm.find_acquisitions_by_orbit_id(orbit.orbit_id, "science", False)
+        # Get acquisitions in orbit (only science with min proc lines, not dark) - radiance and line timestamps
+        acquisitions_in_orbit = dm.find_acquisitions_by_orbit_id(orbit.orbit_id, "science", True)
 
         # Build input_files dictionary
         input_files = {

--- a/emit_main/workflow/l1b_tasks.py
+++ b/emit_main/workflow/l1b_tasks.py
@@ -106,12 +106,16 @@ class L1BCalibrate(SlurmJobTask):
         utils_path = os.path.join(pge.repo_dir, "utils")
         env = os.environ.copy()
         env["PYTHONPATH"] = f"$PYTHONPATH:{utils_path}"
+        instrument_mode = "default"
+        if acq["instrument_mode"] == "cold_img_mid" or acq["instrument_mode"] == "cold_img_mid_vdda":
+            instrument_mode = "half"
         cmd = ["python", emitrdn_exe,
-               "--config_file", tmp_config_path,
-               "--dark_file", dark_img_path,
-               "--log_file", tmp_log_path,
+               "--mode", instrument_mode,
                "--level", self.level,
+               "--log_file", tmp_log_path,
                acq.raw_img_path,
+               dark_img_path,
+               tmp_config_path,
                tmp_rdn_img_path]
         pge.run(cmd, tmp_dir=self.tmp_dir, env=env)
 

--- a/emit_main/workflow/l1b_tasks.py
+++ b/emit_main/workflow/l1b_tasks.py
@@ -91,6 +91,7 @@ class L1BCalibrate(SlurmJobTask):
                 "stop_time",
                 acq.start_time - datetime.timedelta(minutes=400),
                 acq.start_time,
+                instrument_mode=acq["instrument_mode"],
                 min_valid_lines=256,
                 sort=-1)
             if recent_darks is None or len(recent_darks) == 0:

--- a/emit_main/workflow/orbit.py
+++ b/emit_main/workflow/orbit.py
@@ -161,7 +161,7 @@ class Orbit:
         num_science = 0
         for id in acquisition_ids:
             acq = dm.find_acquisition_by_id(id)
-            if acq is not None and acq["submode"] == "science" and acq["has_min_proc_lines"] is True:
+            if acq is not None and acq["submode"] == "science" and acq["num_valid_lines"] > 0:
                 num_science += 1
                 try:
                     rdn_img_path = acq["products"]["l1b"]["rdn"]["img_path"]

--- a/emit_main/workflow/orbit.py
+++ b/emit_main/workflow/orbit.py
@@ -161,7 +161,7 @@ class Orbit:
         num_science = 0
         for id in acquisition_ids:
             acq = dm.find_acquisition_by_id(id)
-            if acq is not None and acq["submode"] == "science" and acq["is_empty"] is False:
+            if acq is not None and acq["submode"] == "science" and acq["has_min_proc_lines"] is True:
                 num_science += 1
                 try:
                     rdn_img_path = acq["products"]["l1b"]["rdn"]["img_path"]


### PR DESCRIPTION
Works with https://github.com/emit-sds/emit-sds-l1a/pull/1

* Use number of valid lines (not missing or cloudy) to decide whether or not to process past L1A.  Science acquisitions are processed if number of valid lines is non-zero, and darks are used if valid lines >= 256.
* Use "--mode half" in L1B calibration if instrument mode is gypsum mode.