### PR TITLE
Failed monitor tasks

### DIFF
--- a/emit_main/database/database_manager.py
+++ b/emit_main/database/database_manager.py
@@ -67,7 +67,7 @@ class DatabaseManager:
         }
         return list(acquisitions_coll.find(query).sort(field, sort))
 
-    def find_acquisitions_for_calibration(self, start, stop):
+    def find_acquisitions_for_calibration(self, start, stop, date_field="last_modified", retry_failed=False):
         acquisitions_coll = self.db.acquisitions
         # Query for "science" acquisitions with non-zero valid lines and with complete l1a raw outputs but no l1b rdn
         # outputs in time range
@@ -76,11 +76,12 @@ class DatabaseManager:
             "num_valid_lines": {"$gte": 1},
             "products.l1a.raw.img_path": {"$exists": 1},
             "products.l1b.rdn.img_path": {"$exists": 0},
-            "last_modified": {"$gte": start, "$lte": stop},
+            date_field: {"$gte": start, "$lte": stop},
             "build_num": self.config["build_num"]
         }
         results = list(acquisitions_coll.find(query))
-        results = self._remove_results_with_failed_tasks(results, ["emit.L1BCalibrate"])
+        if not retry_failed:
+            results = self._remove_results_with_failed_tasks(results, ["emit.L1BCalibrate"])
         acqs_ready_for_cal = []
         for acq in results:
             recent_darks = self.find_acquisitions_touching_date_range(
@@ -95,7 +96,7 @@ class DatabaseManager:
                 acqs_ready_for_cal.append(acq)
         return acqs_ready_for_cal
 
-    def find_acquisitions_for_l2(self, start, stop):
+    def find_acquisitions_for_l2(self, start, stop, date_field="last_modified", retry_failed=False):
         acquisitions_coll = self.db.acquisitions
         # Query for acquisitions with complete l1b outputs but no rfl outputs in time range
         query = {
@@ -104,11 +105,12 @@ class DatabaseManager:
             "products.l1b.loc.img_path": {"$exists": 1},
             "products.l1b.obs.img_path": {"$exists": 1},
             "products.l2a.rfl.img_path": {"$exists": 0},
-            "last_modified": {"$gte": start, "$lte": stop},
+            date_field: {"$gte": start, "$lte": stop},
             "build_num": self.config["build_num"]
         }
         results = list(acquisitions_coll.find(query))
-        results = self._remove_results_with_failed_tasks(results, ["emit.L2BAbundance", "emit.L3Unmix"])
+        if not retry_failed:
+            results = self._remove_results_with_failed_tasks(results, ["emit.L2BAbundance", "emit.L3Unmix"])
         return results
 
     def insert_acquisition(self, metadata):
@@ -157,20 +159,21 @@ class DatabaseManager:
         }
         return list(streams_coll.find(query).sort(field, sort))
 
-    def find_streams_for_edp_reformatting(self, start, stop):
+    def find_streams_for_edp_reformatting(self, start, stop, date_field="last_modified", retry_failed=False):
         streams_coll = self.db.streams
         # Query for 1674 streams that have l0 ccsds products but no l1a products which were last modified between
         # start and stop times (typically they need to be older than a certain amount of time to make sure the
         # 1676 ancillary file exists
         query = {
             "apid": "1674",
-            "last_modified": {"$gte": start, "$lte": stop},
+            date_field: {"$gte": start, "$lte": stop},
             "products.l0.ccsds_path": {"$exists": 1},
             "products.l1a": {"$exists": 0},
             "build_num": self.config["build_num"]
         }
         results = list(streams_coll.find(query))
-        results = self._remove_results_with_failed_tasks(results, ["emit.L1AReformatEDP"])
+        if not retry_failed:
+            results = self._remove_results_with_failed_tasks(results, ["emit.L1AReformatEDP"])
         return results
 
     def insert_stream(self, name, metadata):
@@ -218,18 +221,22 @@ class DatabaseManager:
         data_collections_coll = self.db.data_collections
         return list(data_collections_coll.find({"orbit": orbit_id, "build_num": self.config["build_num"]}))
 
-    def find_data_collections_for_reassembly(self, start, stop):
+    def find_data_collections_for_reassembly(self, start, stop, date_field="frames_last_modified", retry_failed=False):
         data_collections_coll = self.db.data_collections
+        # Use frames_last_modified for date field by default
+        if date_field == "last_modified":
+            date_field = "frames_last_modified"
         # Query for data collections with complete set of frames, last modified within start/stop range and
         # that don't have associated acquisitions
         query = {
             "frames_status": "complete",
-            "frames_last_modified": {"$gte": start, "$lte": stop},
+            date_field: {"$gte": start, "$lte": stop},
             "associated_acquisitions": {"$exists": 0},
             "build_num": self.config["build_num"]
         }
         results = list(data_collections_coll.find(query))
-        results = self._remove_results_with_failed_tasks(results, ["emit.L1AReassembleRaw", "emit.L1AFrameReport"])
+        if not retry_failed:
+            results = self._remove_results_with_failed_tasks(results, ["emit.L1AReassembleRaw", "emit.L1AFrameReport"])
         return results
 
     def insert_data_collection(self, metadata):
@@ -280,33 +287,35 @@ class DatabaseManager:
         }
         return list(orbits_coll.find(query).sort("start_time", sort))
 
-    def find_orbits_for_bad_reformatting(self, start, stop):
+    def find_orbits_for_bad_reformatting(self, start, stop, date_field="last_modified", retry_failed=False):
         orbits_coll = self.db.orbits
         # Query for orbits with complete set of bad data, last modified within start/stop range and
         # that don't have an associated bad netcdf file
         query = {
             "bad_status": "complete",
-            "last_modified": {"$gte": start, "$lte": stop},
+            date_field: {"$gte": start, "$lte": stop},
             "associated_bad_netcdf": {"$exists": 0},
             "build_num": self.config["build_num"]
         }
         results = list(orbits_coll.find(query))
-        results = self._remove_results_with_failed_tasks(results, ["emit.L1AReformatBAD"])
+        if not retry_failed:
+            results = self._remove_results_with_failed_tasks(results, ["emit.L1AReformatBAD"])
         return results
 
-    def find_orbits_for_geolocation(self, start, stop):
+    def find_orbits_for_geolocation(self, start, stop, date_field="last_modified", retry_failed=False):
         orbits_coll = self.db.orbits
         # Query for orbits with complete set of radiance files, an associated BAD netcdf file, last modified within
         # start/stop range, and no products.l1b.acquisitions
         query = {
             "radiance_status": "complete",
-            "last_modified": {"$gte": start, "$lte": stop},
+            date_field: {"$gte": start, "$lte": stop},
             "associated_bad_netcdf": {"$exists": 1},
             "products.l1b.acquisitions": {"$exists": 0},
             "build_num": self.config["build_num"]
         }
         results =  list(orbits_coll.find(query))
-        results = self._remove_results_with_failed_tasks(results, ["emit.L1BGeolocate"])
+        if not retry_failed:
+            results = self._remove_results_with_failed_tasks(results, ["emit.L1BGeolocate"])
         return results
 
     def insert_orbit(self, metadata):

--- a/emit_main/database/database_manager.py
+++ b/emit_main/database/database_manager.py
@@ -313,7 +313,7 @@ class DatabaseManager:
             "products.l1b.acquisitions": {"$exists": 0},
             "build_num": self.config["build_num"]
         }
-        results =  list(orbits_coll.find(query))
+        results = list(orbits_coll.find(query))
         if not retry_failed:
             results = self._remove_results_with_failed_tasks(results, ["emit.L1BGeolocate"])
         return results

--- a/emit_main/monitor/acquisition_monitor.py
+++ b/emit_main/monitor/acquisition_monitor.py
@@ -30,15 +30,16 @@ class AcquisitionMonitor:
         # Get workflow manager
         self.wm = WorkflowManager(config_path=config_path)
 
-    def get_calibration_tasks(self, start_time, stop_time):
+    def get_calibration_tasks(self, start_time, stop_time, date_field="last_modified", retry_failed=False):
         tasks = []
         # Find acquisitions within time range
         dm = self.wm.database_manager
-        acquisitions = dm.find_acquisitions_for_calibration(start=start_time, stop=stop_time)
+        acquisitions = dm.find_acquisitions_for_calibration(start=start_time, stop=stop_time, date_field=date_field,
+                                                            retry_failed=retry_failed)
 
         # If no results, just return empty list
         if len(acquisitions) == 0:
-            logger.info(f"Did not find any acquisitions modified between {start_time} and {stop_time} needing "
+            logger.info(f"Did not find any acquisitions with {date_field} between {start_time} and {stop_time} needing "
                         f"calibration tasks. Not executing any tasks.")
             return tasks
 
@@ -51,16 +52,17 @@ class AcquisitionMonitor:
 
         return tasks
 
-    def get_l2_tasks(self, start_time, stop_time):
+    def get_l2_tasks(self, start_time, stop_time, date_field="last_modified", retry_failed=False):
         tasks = []
         # Find acquisitions within time range
         dm = self.wm.database_manager
-        acquisitions = dm.find_acquisitions_for_l2(start=start_time, stop=stop_time)
+        acquisitions = dm.find_acquisitions_for_l2(start=start_time, stop=stop_time, date_field=date_field,
+                                                   retry_failed=retry_failed)
 
         # If no results, just return empty list
         if len(acquisitions) == 0:
-            logger.info(f"Did not find any acquisitions modified between {start_time} and {stop_time} needing MESMA "
-                        f"tasks. Not executing any tasks.")
+            logger.info(f"Did not find any acquisitions with {date_field} between {start_time} and {stop_time} needing "
+                        f"MESMA tasks. Not executing any tasks.")
             return tasks
 
         for acq in acquisitions:

--- a/emit_main/monitor/frames_monitor.py
+++ b/emit_main/monitor/frames_monitor.py
@@ -33,15 +33,16 @@ class FramesMonitor:
         # Get workflow manager
         self.wm = WorkflowManager(config_path=config_path)
 
-    def get_reassembly_tasks(self, start_time, stop_time):
+    def get_reassembly_tasks(self, start_time, stop_time, date_field="frames_last_modified", retry_failed=False):
         tasks = []
         dm = self.wm.database_manager
-        data_collections = dm.find_data_collections_for_reassembly(start=start_time, stop=stop_time)
+        data_collections = dm.find_data_collections_for_reassembly(start=start_time, stop=stop_time,
+                                                                   date_field=date_field, retry_failed=retry_failed)
 
         # If no results, just return empty list
         if len(data_collections) == 0:
-            logger.info(f"Did not find any data collections modified between {start_time} and {stop_time} needing "
-                        f"reassembly tasks. Not executing any tasks.")
+            logger.info(f"Did not find any data collections with {date_field} between {start_time} and {stop_time} "
+                        f"needing reassembly tasks. Not executing any tasks.")
             return tasks
 
         for dc in data_collections:

--- a/emit_main/monitor/ingest_monitor.py
+++ b/emit_main/monitor/ingest_monitor.py
@@ -57,16 +57,17 @@ class IngestMonitor:
         logger.info(f"Found paths to ingest: {paths}")
         return self._ingest_file_list(paths)
 
-    def get_edp_reformatting_tasks(self, start_time, stop_time):
+    def get_edp_reformatting_tasks(self, start_time, stop_time, date_field="last_modified", retry_failed=False):
         tasks = []
         # Find 1674 files in time range that don't have engineering products yet
         dm = self.wm.database_manager
-        streams = dm.find_streams_for_edp_reformatting(start=start_time, stop=stop_time)
+        streams = dm.find_streams_for_edp_reformatting(start=start_time, stop=stop_time, date_field=date_field,
+                                                       retry_failed=retry_failed)
 
         # If no results, just return empty list
         if len(streams) == 0:
-            logger.info(f"Did not find any 1674 streams modified between {start_time} and {stop_time} needing EDP "
-                        f"reformatting tasks. Not executing any tasks.")
+            logger.info(f"Did not find any 1674 streams with {date_field} between {start_time} and {stop_time} needing "
+                        f"EDP reformatting tasks. Not executing any tasks.")
             return tasks
 
         for stream in streams:

--- a/emit_main/monitor/orbit_monitor.py
+++ b/emit_main/monitor/orbit_monitor.py
@@ -29,15 +29,16 @@ class OrbitMonitor:
         # Get workflow manager
         self.wm = WorkflowManager(config_path=config_path)
 
-    def get_bad_reformatting_tasks(self, start_time, stop_time):
+    def get_bad_reformatting_tasks(self, start_time, stop_time, date_field="last_modified", retry_failed=False):
         tasks = []
         # Find orbits within time range
         dm = self.wm.database_manager
-        orbits = dm.find_orbits_for_bad_reformatting(start=start_time, stop=stop_time)
+        orbits = dm.find_orbits_for_bad_reformatting(start=start_time, stop=stop_time, date_field=date_field,
+                                                     retry_failed=retry_failed)
 
         # If no results, just return empty list
         if len(orbits) == 0:
-            logger.info(f"Did not find any orbits modified between {start_time} and {stop_time} needing BAD "
+            logger.info(f"Did not find any orbits with {date_field} between {start_time} and {stop_time} needing BAD "
                         f"reformatting tasks. Not executing any tasks.")
             return tasks
 
@@ -50,16 +51,17 @@ class OrbitMonitor:
 
         return tasks
 
-    def get_geolocation_tasks(self, start_time, stop_time):
+    def get_geolocation_tasks(self, start_time, stop_time, date_field="last_modified", retry_failed=False):
         tasks = []
         # Find orbits within time range
         dm = self.wm.database_manager
-        orbits = dm.find_orbits_for_geolocation(start=start_time, stop=stop_time)
+        orbits = dm.find_orbits_for_geolocation(start=start_time, stop=stop_time, date_field=date_field,
+                                                retry_failed=retry_failed)
 
         # If no results, just return empty list
         if len(orbits) == 0:
-            logger.info(f"Did not find any orbits modified between {start_time} and {stop_time} needing geolocation "
-                        f"tasks. Not executing any tasks.")
+            logger.info(f"Did not find any orbits with {date_field} between {start_time} and {stop_time} needing "
+                        f"geolocation tasks. Not executing any tasks.")
             return tasks
 
         for orbit in orbits:

--- a/emit_main/run_workflow.py
+++ b/emit_main/run_workflow.py
@@ -71,6 +71,10 @@ def parse_args():
                         help="The start time to use for any monitor calls (YYYY-MM-DDTHH:MM:SS)")
     parser.add_argument("--stop_time",
                         help="The stop time to use for any monitor calls (YYYY-MM-DDTHH:MM:SS)")
+    parser.add_argument("--date_field", default="last_modified",
+                        help="The date field for the monitors to query")
+    parser.add_argument("--retry_failed", action="store_true",
+                        help="A flag to tell the monitors to retry failed tasks.")
     parser.add_argument("--miss_pkt_thresh", default="0.1",
                         help="The threshold of missing packets to total packets which will cause a task to fail")
     parser.add_argument("--ignore_missing_frames", action="store_true",
@@ -333,7 +337,8 @@ def main():
     if args.monitor and args.monitor == "frames":
         fm = FramesMonitor(config_path=args.config_path, level=args.level, partition=args.partition,
                            acq_chunksize=args.acq_chunksize, test_mode=args.test_mode)
-        fm_tasks = fm.get_reassembly_tasks(start_time=args.start_time, stop_time=args.stop_time)
+        fm_tasks = fm.get_reassembly_tasks(start_time=args.start_time, stop_time=args.stop_time,
+                                           date_field=args.date_field, retry_failed=args.retry_failed)
         fm_tasks_str = "\n".join([str(t) for t in fm_tasks])
         logger.info(f"Frames monitor tasks to run:\n{fm_tasks_str}")
         tasks += fm_tasks
@@ -342,7 +347,8 @@ def main():
     if args.monitor and args.monitor == "edp":
         im = IngestMonitor(config_path=args.config_path, level=args.level, partition=args.partition,
                            miss_pkt_thresh=args.miss_pkt_thresh, test_mode=args.test_mode)
-        im_edp_tasks = im.get_edp_reformatting_tasks(start_time=args.start_time, stop_time=args.stop_time)
+        im_edp_tasks = im.get_edp_reformatting_tasks(start_time=args.start_time, stop_time=args.stop_time,
+                                                     date_field=args.date_field, retry_failed=args.retry_failed)
         im_edp_tasks_str = "\n".join([str(t) for t in im_edp_tasks])
         logger.info(f"Ingest monitor EDP tasks to run:\n{im_edp_tasks_str}")
         tasks += im_edp_tasks
@@ -350,7 +356,8 @@ def main():
     # Get tasks from orbit monitor for BAD tasks
     if args.monitor and args.monitor == "bad":
         om = OrbitMonitor(config_path=args.config_path, level=args.level, partition=args.partition)
-        om_bad_tasks = om.get_bad_reformatting_tasks(start_time=args.start_time, stop_time=args.stop_time)
+        om_bad_tasks = om.get_bad_reformatting_tasks(start_time=args.start_time, stop_time=args.stop_time,
+                                                     date_field=args.date_field, retry_failed=args.retry_failed)
         om_bad_tasks_str = "\n".join([str(t) for t in om_bad_tasks])
         logger.info(f"Orbit monitor BAD tasks to run:\n{om_bad_tasks_str}")
         tasks += om_bad_tasks
@@ -358,7 +365,8 @@ def main():
     # Get tasks from orbit monitor for geolocation tasks
     if args.monitor and args.monitor == "geo":
         om = OrbitMonitor(config_path=args.config_path, level=args.level, partition=args.partition)
-        om_geo_tasks = om.get_geolocation_tasks(start_time=args.start_time, stop_time=args.stop_time)
+        om_geo_tasks = om.get_geolocation_tasks(start_time=args.start_time, stop_time=args.stop_time,
+                                                date_field=args.date_field, retry_failed=args.retry_failed)
         om_geo_tasks_str = "\n".join([str(t) for t in om_geo_tasks])
         logger.info(f"Orbit monitor geolocation tasks to run:\n{om_geo_tasks_str}")
         tasks += om_geo_tasks
@@ -366,7 +374,8 @@ def main():
     # Get tasks from acquisition monitor for calibration tasks
     if args.monitor and args.monitor == "cal":
         am = AcquisitionMonitor(config_path=args.config_path, level=args.level, partition=args.partition)
-        am_cal_tasks = am.get_calibration_tasks(start_time=args.start_time, stop_time=args.stop_time)
+        am_cal_tasks = am.get_calibration_tasks(start_time=args.start_time, stop_time=args.stop_time,
+                                                date_field=args.date_field, retry_failed=args.retry_failed)
         am_cal_tasks_str = "\n".join([str(t) for t in am_cal_tasks])
         logger.info(f"Acquisition monitor calibration tasks to run:\n{am_cal_tasks_str}")
         tasks += am_cal_tasks
@@ -374,7 +383,8 @@ def main():
     # Get tasks from acquisition monitor for L2+ tasks
     if args.monitor and args.monitor == "l2":
         am = AcquisitionMonitor(config_path=args.config_path, level=args.level, partition=args.partition)
-        am_l2_tasks = am.get_l2_tasks(start_time=args.start_time, stop_time=args.stop_time)
+        am_l2_tasks = am.get_l2_tasks(start_time=args.start_time, stop_time=args.stop_time,
+                                      date_field=args.date_field, retry_failed=args.retry_failed)
         am_l2_tasks_str = "\n".join([str(t) for t in am_l2_tasks])
         logger.info(f"Acquisition monitor L2 tasks to run:\n{am_l2_tasks_str}")
         tasks += am_l2_tasks


### PR DESCRIPTION
This update adds in new logic when the monitors are querying for tasks to run.  If a task has previously failed, then the monitor will not try to run it again.

This update adds in two new workflow arguments for monitors:
* --date_field defaults to "last_modified" and specifies which date field the monitor should use when querying the database and looking for products to process.  The other likely option is "start_time".
* --retry_failed allows the user to override the monitor logic and force it to retry a task that has failed before.