### PR TITLE
Refl updates

### DIFF
--- a/emit_main/config/ops_sds_config.json
+++ b/emit_main/config/ops_sds_config.json
@@ -5,8 +5,8 @@
     "processing_version": "01",
     "luigi_local_scheduler": false,
     "luigi_workers": 2,
-    "tetracorder_library_basename": "06emitb",
-    "tetracorder_library_cmdname": "emit_b"
+    "tetracorder_library_basename": "06emitc",
+    "tetracorder_library_cmdname": "emit_c"
   },
 
   "filesystem_config": {
@@ -54,7 +54,7 @@
     "l1b_config_path": "repos/emit-sds-l1b/config/EMIT_20220902.json",
     "l1b_geo_install_dir": "/store/emit/ops/repos/emit_l1b_geo_installs/1.5.0_hf6",
     "l1b_geo_osp_dir": "/store/emit/ops/repos/emit_l1b_osp_installs/1.5.0_hf6",
-    "isofit_surface_config": "repos/emit-sds-l2a/surface/surface_20220714.json",
+    "isofit_surface_config": "repos/emit-sds-l2a/surface/surface_20220908.json",
     "isofit_emulator_base": "/beegfs/store/shared/sRTMnet_v110.h5",
     "isofit_sixs_dir": "/beegfs/store/shared/sixs",
     "specpr_path": "/beegfs/store/shared/specpr",

--- a/emit_main/workflow/acquisition.py
+++ b/emit_main/workflow/acquisition.py
@@ -113,6 +113,8 @@ class Acquisition:
             },
             "l1b": {
                 "rdn": ["img", "hdr", "png", "kmz", "nc"],
+                "destripedark": ["img", "hdr"],
+                "destripeff": ["img", "hdr"],
                 "loc": ["img", "hdr"],
                 "obs": ["img", "hdr", "nc"],
                 "glt": ["img", "hdr"],

--- a/emit_main/workflow/l1b_tasks.py
+++ b/emit_main/workflow/l1b_tasks.py
@@ -171,13 +171,10 @@ class L1BCalibrate(SlurmJobTask):
         pge.run(cmd_ds, tmp_dir=self.tmp_dir, env=env)
 
         # Copy output files to l1b dir (all but pre-destripped radiance)
-        wm.copy(tmp_rdn_destripe_img_path, acq.rdn_img_path)
-        wm.copy(envi_header(tmp_rdn_destripe_img_path), acq.rdn_hdr_path)
-        wm.copy(tmp_rdn_destripe_dark_img_path, acq.l1b_data_dir)
-        wm.copy(envi_header(tmp_rdn_destripe_dark_img_path), acq.l1b_data_dir)
-        wm.copy(tmp_rdn_destripe_flatfield_img_path, acq.l1b_data_dir)
-        wm.copy(envi_header(tmp_rdn_destripe_flatfield_img_path), acq.l1b_data_dir)
-        wm.copy(tmp_log_path, acq.l1b_data_dir)
+        for fn in [tmp_rdn_destripe_img_path, tmp_rdn_destripe_dark_img_path, tmp_rdn_destripe_flatfield_img_path]:
+            wm.copy(fn, os.path.join(acq.l1b_data_dir, os.path.basename(fn)))
+            wm.copy(envi_header(fn), os.path.join(acq.l1b_data_dir, os.path.basename(envi_header(fn))))
+        wm.copy(tmp_log_path, os.path.join(acq.l1b_data_dir, os.path.basename(tmp_log_path)) )
 
         # Update hdr files
         input_files_arr = ["{}={}".format(key, value) for key, value in input_files.items()]

--- a/emit_main/workflow/l1b_tasks.py
+++ b/emit_main/workflow/l1b_tasks.py
@@ -173,10 +173,10 @@ class L1BCalibrate(SlurmJobTask):
         # Copy output files to l1b dir (all but pre-destripped radiance)
         wm.copy(tmp_rdn_destripe_img_path, acq.rdn_img_path)
         wm.copy(envi_header(tmp_rdn_destripe_img_path), acq.rdn_hdr_path)
-        wm.copy(tmp_rdn_destripe_dark_img_path, os.path.join(acq.l1b_data_dir, os.path.basename(tmp_rdn_destripe_dark_img_path)))
-        wm.copy(envi_header(tmp_rdn_destripe_dark_img_path), os.path.join(acq.l1b_data_dir, os.path.basename(tmp_rdn_destripe_dark_img_path)))
-        wm.copy(tmp_rdn_destripe_flatfield_img_path, os.path.join(acq.l1b_data_dir, os.path.basename(tmp_rdn_destripe_flatfield_img_path)))
-        wm.copy(envi_header(tmp_rdn_destripe_flatfield_img_path), os.path.join(acq.l1b_data_dir, os.path.basename(envi_header(tmp_rdn_destripe_flatfield_img_path))))
+        wm.copy(tmp_rdn_destripe_dark_img_path, acq.destripedark_img_path)
+        wm.copy(envi_header(tmp_rdn_destripe_dark_img_path), acq.destripedark_hdr_path)
+        wm.copy(tmp_rdn_destripe_flatfield_img_path, acq.destripeff_img_path)
+        wm.copy(envi_header(tmp_rdn_destripe_flatfield_img_path), acq.destripeff_hdr_path)
         wm.copy(tmp_log_path, os.path.join(acq.l1b_data_dir, os.path.basename(tmp_log_path)) )
 
         # Update hdr files

--- a/emit_main/workflow/l1b_tasks.py
+++ b/emit_main/workflow/l1b_tasks.py
@@ -171,9 +171,12 @@ class L1BCalibrate(SlurmJobTask):
         pge.run(cmd_ds, tmp_dir=self.tmp_dir, env=env)
 
         # Copy output files to l1b dir (all but pre-destripped radiance)
-        for fn in [tmp_rdn_destripe_img_path, tmp_rdn_destripe_dark_img_path, tmp_rdn_destripe_flatfield_img_path]:
-            wm.copy(fn, os.path.join(acq.l1b_data_dir, os.path.basename(fn)))
-            wm.copy(envi_header(fn), os.path.join(acq.l1b_data_dir, os.path.basename(envi_header(fn))))
+        wm.copy(tmp_rdn_destripe_img_path, acq.rdn_img_path)
+        wm.copy(envi_header(tmp_rdn_destripe_img_path), acq.rdn_hdr_path)
+        wm.copy(tmp_rdn_destripe_dark_img_path, os.path.join(acq.l1b_data_dir, os.path.basename(tmp_rdn_destripe_dark_img_path)))
+        wm.copy(envi_header(tmp_rdn_destripe_dark_img_path), os.path.join(acq.l1b_data_dir, os.path.basename(tmp_rdn_destripe_dark_img_path)))
+        wm.copy(tmp_rdn_destripe_flatfield_img_path, os.path.join(acq.l1b_data_dir, os.path.basename(tmp_rdn_destripe_flatfield_img_path)))
+        wm.copy(envi_header(tmp_rdn_destripe_flatfield_img_path), os.path.join(acq.l1b_data_dir, os.path.basename(envi_header(tmp_rdn_destripe_flatfield_img_path))))
         wm.copy(tmp_log_path, os.path.join(acq.l1b_data_dir, os.path.basename(tmp_log_path)) )
 
         # Update hdr files

--- a/emit_main/workflow/l2a_tasks.py
+++ b/emit_main/workflow/l2a_tasks.py
@@ -163,6 +163,7 @@ class L2AReflectance(SlurmJobTask):
         dm = wm.database_manager
         for img_path, hdr_path in [(acq.rfl_img_path, acq.rfl_hdr_path), (acq.rfluncert_img_path, acq.rfluncert_hdr_path)]:
             hdr = envi.read_envi_header(hdr_path)
+            hdr["description"] = "{{EMIT L2A surface reflectance (0-1)}}"
             hdr["emit acquisition start time"] = acq.start_time_with_tz.strftime("%Y-%m-%dT%H:%M:%S%z")
             hdr["emit acquisition stop time"] = acq.stop_time_with_tz.strftime("%Y-%m-%dT%H:%M:%S%z")
             hdr["emit pge name"] = pge.repo_url

--- a/emit_main/workflow/l2a_tasks.py
+++ b/emit_main/workflow/l2a_tasks.py
@@ -112,7 +112,9 @@ class L2AReflectance(SlurmJobTask):
                "--surface_path", tmp_surface_path,
                "--ray_temp_dir", "/tmp/ray",
                "--log_file", tmp_log_path,
-               "--logging_level", self.level]
+               "--logging_level", self.level,
+               "--num_neighbors=10",
+               "--pressure_elevation"]
 
         env["SIXS_DIR"] = wm.config["isofit_sixs_dir"]
         env["EMULATOR_DIR"] = emulator_base

--- a/emit_main/workflow/l2a_tasks.py
+++ b/emit_main/workflow/l2a_tasks.py
@@ -135,8 +135,8 @@ class L2AReflectance(SlurmJobTask):
         tmp_statesubs_hdr_path = envi_header(tmp_statesubs_path)
         tmp_quality_path = os.path.join(self.local_tmp_dir, "output", self.acquisition_id + "_rfl_quality.txt")
 
-        cmd = ["gdal_translate", tmp_rfl_path, tmp_rfl_png_path, "-b", "32", "-b", "22", "-b",
-               "13", "-ot", "Byte", "-scale", "-exponent", "0.6", "-of", "PNG", "-co", "ZLEVEL=9"]
+        cmd = ["gdal_translate", tmp_rfl_path, tmp_rfl_png_path, "-b", "35", "-b", "23", "-b",
+               "11", "-ot", "Byte", "-scale", "-exponent", "0.6", "-of", "PNG", "-co", "ZLEVEL=9"]
         pge.run(cmd, tmp_dir=self.tmp_dir, env=env)
 
         cmd = ["python", os.path.join(pge.repo_dir, "spectrum_quality.py"), tmp_rfl_path, tmp_quality_path]


### PR DESCRIPTION
Updated l1b call for destripe and reflectance prior / isofit call updates.  Requires:

- build number increment
- latest isofit version (to be 2.9.4)
- latest l2a repo with new prior .json