### PR TITLE
Well Known Errors

### DIFF
--- a/emit_main/config/config.py
+++ b/emit_main/config/config.py
@@ -52,7 +52,7 @@ class Config:
             # Get passwords from resources/credentials directory
             self.dictionary.update(self._get_passwords())
             
-            # Added well known errors
+            # Add well known errors
             self.dictionary['well_known_errors'] = config['well_known_errors']
 
     def _get_product_config_paths(self, product_config, timestamp):

--- a/emit_main/config/config.py
+++ b/emit_main/config/config.py
@@ -51,6 +51,9 @@ class Config:
 
             # Get passwords from resources/credentials directory
             self.dictionary.update(self._get_passwords())
+            
+            # Added well known errors
+            self.dictionary['well_known_errors'] = config['well_known_errors']
 
     def _get_product_config_paths(self, product_config, timestamp):
         # Get the products paths that are either absolute paths or relative to the environment directory

--- a/emit_main/config/dev_sds_config.json
+++ b/emit_main/config/dev_sds_config.json
@@ -106,5 +106,5 @@
         "config_comments": "Calibration change in response to anomaly on 2025-07-13T16:25:00Z."
       }
     }
-  }
+}
 }

--- a/emit_main/config/dev_sds_config.json
+++ b/emit_main/config/dev_sds_config.json
@@ -104,7 +104,19 @@
         "l1b_config_path": "/store/emit/dev/repos/emit-sds-l1b/config/EMIT_20250721.json",
         "frame_hdr_format": "1.0",
         "config_comments": "Calibration change in response to anomaly on 2025-07-13T16:25:00Z."
-      }
+            }
+        }
+    },
+  "well_known_errors": {
+        "emit.L1BGeolocate": [
+        "RuntimeError: Opening GDAL file",
+        "reference_surface_intersect_approximate failed to find a solution"
+        ],
+        "emit.L1BCalibrate": [
+        "AttributeError: 'NoneType' object has no attribute 'decode'"
+        ],
+        "emit.L2AReflectance": [
+        "IndexError: index 2 is out of bounds for axis 1 with size 2"
+        ]
     }
-}
 }

--- a/emit_main/config/ops_sds_config.json
+++ b/emit_main/config/ops_sds_config.json
@@ -106,5 +106,23 @@
                 "config_comments": "Calibration change in response to anomaly on 2025-07-13T16:25:00Z."
             }
         }
+    },
+  "well_known_errors": {
+        "emit.L1BGeolocate": [
+        "Out of range error in file",
+        "Don't yet work when we cross the dateline",
+        "RuntimeError: Opening GDAL file",
+        "reference_surface_intersect_approximate failed to find a solution",
+        "Time_list needs to be strictly ordered"
+        ],
+        "emit.L1BCalibrate": [
+        "AttributeError: 'NoneType' object has no attribute 'decode'"
+        ],
+        "emit.L2AReflectance": [
+        "ValueError: shape mismatch: value array of shape",
+        "numpy.linalg.LinAlgError: unrecoverable internal error",
+        "IndexError: cannot do a non-empty take from an empty axe",
+        "IndexError: index 2 is out of bounds for axis 1 with size 2"
+        ]
     }
 }

--- a/emit_main/config/ops_sds_config.json
+++ b/emit_main/config/ops_sds_config.json
@@ -106,7 +106,7 @@
                 "config_comments": "Calibration change in response to anomaly on 2025-07-13T16:25:00Z."
             }
         }
-    },,
+    },
   "well_known_errors": {
         "emit.L1BGeolocate": [
         "RuntimeError: Opening GDAL file",

--- a/emit_main/config/ops_sds_config.json
+++ b/emit_main/config/ops_sds_config.json
@@ -106,22 +106,16 @@
                 "config_comments": "Calibration change in response to anomaly on 2025-07-13T16:25:00Z."
             }
         }
-    },
+    },,
   "well_known_errors": {
         "emit.L1BGeolocate": [
-        "Out of range error in file",
-        "Don't yet work when we cross the dateline",
         "RuntimeError: Opening GDAL file",
-        "reference_surface_intersect_approximate failed to find a solution",
-        "Time_list needs to be strictly ordered"
+        "reference_surface_intersect_approximate failed to find a solution"
         ],
         "emit.L1BCalibrate": [
         "AttributeError: 'NoneType' object has no attribute 'decode'"
         ],
         "emit.L2AReflectance": [
-        "ValueError: shape mismatch: value array of shape",
-        "numpy.linalg.LinAlgError: unrecoverable internal error",
-        "IndexError: cannot do a non-empty take from an empty axe",
         "IndexError: index 2 is out of bounds for axis 1 with size 2"
         ]
     }

--- a/emit_main/config/test_sds_config.json
+++ b/emit_main/config/test_sds_config.json
@@ -114,7 +114,7 @@
             }
         }
     },
-    "well_known_errors": {
+  "well_known_errors": {
         "emit.L1BGeolocate": [
         "Out of range error in file",
         "Don't yet work when we cross the dateline",
@@ -128,7 +128,8 @@
         "emit.L2AReflectance": [
         "ValueError: shape mismatch: value array of shape",
         "numpy.linalg.LinAlgError: unrecoverable internal error",
-        "IndexError: cannot do a non-empty take from an empty axe"
+        "IndexError: cannot do a non-empty take from an empty axe",
+        "IndexError: index 2 is out of bounds for axis 1 with size 2"
         ]
     }
 }

--- a/emit_main/config/test_sds_config.json
+++ b/emit_main/config/test_sds_config.json
@@ -116,19 +116,13 @@
     },
   "well_known_errors": {
         "emit.L1BGeolocate": [
-        "Out of range error in file",
-        "Don't yet work when we cross the dateline",
         "RuntimeError: Opening GDAL file",
-        "reference_surface_intersect_approximate failed to find a solution",
-        "Time_list needs to be strictly ordered"
+        "reference_surface_intersect_approximate failed to find a solution"
         ],
         "emit.L1BCalibrate": [
         "AttributeError: 'NoneType' object has no attribute 'decode'"
         ],
         "emit.L2AReflectance": [
-        "ValueError: shape mismatch: value array of shape",
-        "numpy.linalg.LinAlgError: unrecoverable internal error",
-        "IndexError: cannot do a non-empty take from an empty axe",
         "IndexError: index 2 is out of bounds for axis 1 with size 2"
         ]
     }

--- a/emit_main/config/test_sds_config.json
+++ b/emit_main/config/test_sds_config.json
@@ -112,23 +112,23 @@
                 "frame_hdr_format": "1.5",
                 "config_comments": "Update frame header to version 1.5 to match FSW v1.5.0 uplink."
             }
-        },
-        "well_known_errors": {
-            "emit.L1BGeolocate": [
-            "Out of range error in file",
-            "Don't yet work when we cross the dateline",
-            "RuntimeError: Opening GDAL file",
-            "reference_surface_intersect_approximate failed to find a solution",
-            "Time_list needs to be strictly ordered"
-            ],
-            "emit.L1BCalibrate": [
-            "AttributeError: 'NoneType' object has no attribute 'decode'"
-            ],
-            "emit.L2AReflectance": [
-            "ValueError: shape mismatch: value array of shape",
-            "numpy.linalg.LinAlgError: unrecoverable internal error",
-            "IndexError: cannot do a non-empty take from an empty axe"
-            ]
         }
+    },
+    "well_known_errors": {
+        "emit.L1BGeolocate": [
+        "Out of range error in file",
+        "Don't yet work when we cross the dateline",
+        "RuntimeError: Opening GDAL file",
+        "reference_surface_intersect_approximate failed to find a solution",
+        "Time_list needs to be strictly ordered"
+        ],
+        "emit.L1BCalibrate": [
+        "AttributeError: 'NoneType' object has no attribute 'decode'"
+        ],
+        "emit.L2AReflectance": [
+        "ValueError: shape mismatch: value array of shape",
+        "numpy.linalg.LinAlgError: unrecoverable internal error",
+        "IndexError: cannot do a non-empty take from an empty axe"
+        ]
     }
 }

--- a/emit_main/config/test_sds_config.json
+++ b/emit_main/config/test_sds_config.json
@@ -112,6 +112,23 @@
                 "frame_hdr_format": "1.5",
                 "config_comments": "Update frame header to version 1.5 to match FSW v1.5.0 uplink."
             }
+        },
+        "well_known_errors": {
+            "emit.L1BGeolocate": [
+            "Out of range error in file",
+            "Don't yet work when we cross the dateline",
+            "RuntimeError: Opening GDAL file",
+            "reference_surface_intersect_approximate failed to find a solution",
+            "Time_list needs to be strictly ordered"
+            ],
+            "emit.L1BCalibrate": [
+            "AttributeError: 'NoneType' object has no attribute 'decode'"
+            ],
+            "emit.L2AReflectance": [
+            "ValueError: shape mismatch: value array of shape",
+            "numpy.linalg.LinAlgError: unrecoverable internal error",
+            "IndexError: cannot do a non-empty take from an empty axe"
+            ]
         }
     }
 }

--- a/emit_main/workflow/l2a_tasks.py
+++ b/emit_main/workflow/l2a_tasks.py
@@ -143,7 +143,7 @@ class L2AReflectance(SlurmJobTask):
 
         cmd = ["python", os.path.join(pge.repo_dir, "spectrum_quality.py"), tmp_rfl_path, tmp_quality_path]
         pge.run(cmd, tmp_dir=self.tmp_dir, env=env)
-        quality_results = np.genfromtxt(tmp_quality_path)
+        quality_results = np.genfromtxt(tmp_quality_path, dtype=str, delimiter="\n")
 
         wm.copy(tmp_rfl_path, acq.rfl_img_path)
         wm.copy(tmp_rfl_hdr_path, acq.rfl_hdr_path)


### PR DESCRIPTION
- This update adds a method `_remove_results_with_well_known_errors` that filters out results containing failures caused by well-known errors, using the well-known errors list defined in the config file to exclude matching failures from the processing log.
- Updated `np.genfromtxt` call to explicitly read quality results as strings line-by-line by setting `dtype=str` and `delimiter="\n"`. This change allows proper opening and handling of results produced by the updated `spectrum_quality.py`.