### PR TITLE
Updated slurm resources for GHG task

### DIFF
--- a/emit_main/workflow/ghg_tasks.py
+++ b/emit_main/workflow/ghg_tasks.py
@@ -45,8 +45,8 @@ class CH4(SlurmJobTask):
     level = luigi.Parameter()
     partition = luigi.Parameter()
 
-    n_cores = 64
-    memory = 360000
+    n_cores = 1
+    memory = 10000
 
     task_namespace = "emit"
 


### PR DESCRIPTION
- Reduced Slurm resource requirements for GHG processing from 64 to 1 core and from 360000 MB to 10000 MB, following [Remove ray #45](https://github.com/emit-sds/emit-ghg/pull/45), which removes Ray as a dependency for the matched filter and enables serial execution with reduced compute time.
- Successfully processed multiple acquisitions simultaneously on a single node.
- Depends on deployment of [PR #48](https://github.com/emit-sds/emit-ghg/pull/48)