### PR TITLE
Added max_jobs to L1BCalibrate run config

### DIFF
--- a/emit_main/workflow/l1b_tasks.py
+++ b/emit_main/workflow/l1b_tasks.py
@@ -186,7 +186,8 @@ class L1BCalibrate(SlurmJobTask):
             "dark_img_path": dark_img_path,
             "l1b_config": l1b_config,
             "l1b_config_path": l1b_config_path,
-            "flat_field_update_paths": flat_field_update_paths
+            "flat_field_update_paths": flat_field_update_paths,
+            'max_jobs': self.n_cores 
         }
         with open(tmp_runconfig_path, "w") as f:
             f.write(json.dumps(runconfig, indent=4))

--- a/emit_main/workflow/l1b_tasks.py
+++ b/emit_main/workflow/l1b_tasks.py
@@ -187,7 +187,7 @@ class L1BCalibrate(SlurmJobTask):
             "l1b_config": l1b_config,
             "l1b_config_path": l1b_config_path,
             "flat_field_update_paths": flat_field_update_paths,
-            'max_jobs': self.n_cores 
+            "max_jobs": self.n_cores 
         }
         with open(tmp_runconfig_path, "w") as f:
             f.write(json.dumps(runconfig, indent=4))


### PR DESCRIPTION
Added `max_jobs` to the run config and set it equal to `n_cores`.